### PR TITLE
Add negative check to integer statistic gathering

### DIFF
--- a/app/src/main/java/games/MarvelRivals.java
+++ b/app/src/main/java/games/MarvelRivals.java
@@ -36,10 +36,6 @@ public class MarvelRivals extends Game<MarvelRivalsMode> {
     public int calculateReps() {
         int deaths = (int) this.statValues.get("deaths");
 
-        if (deaths < 0) {
-            throw new IllegalArgumentException("Deaths (" + deaths + ") cannot be negative");
-        }
-
         return (deaths == 0 ? 1 : deaths) * (this.win ? 1 : 2);
     }
 

--- a/app/src/main/java/workout_processing/GetGame.java
+++ b/app/src/main/java/workout_processing/GetGame.java
@@ -213,10 +213,18 @@ public class GetGame {
             System.out.println("\n\nWhat did you get for " + stat + "?");
             String resp = this.sc.nextLine().strip();
 
+            int statInt = -1;
             try {
-                return Integer.parseInt(resp);
+                statInt = Integer.parseInt(resp);
             } catch (NumberFormatException | NullPointerException e) {
-                System.out.println("\nPlease enter an integer value");
+                System.out.println("\nPlease enter a non-negative integer value");
+                continue;
+            }
+
+            if (statInt >= 0) {
+                return statInt;
+            } else {
+                System.out.println("\nPlease enter a non-negative integer value");
                 continue;
             }
         }

--- a/app/src/test/java/games/MarvelRivalsTest.java
+++ b/app/src/test/java/games/MarvelRivalsTest.java
@@ -33,16 +33,6 @@ public class MarvelRivalsTest {
     }
 
     @Test
-    public void calculateRepsNegIntStat_throwsError() {
-        Map<String, Object> statValues = Map.of("kills", 20, "deaths", -4, "assists", 9);
-
-        MarvelRivals mr = new MarvelRivals(Timestamp.from(Instant.now()), MarvelRivalsMode.UNKNOWN_MODE, statValues, false);
-
-        assertThrows(IllegalArgumentException.class, () -> mr.calculateReps(),
-                "Negative int stat (deaths) should cause an IllegalArgumentException");
-    }
-
-    @Test
     public void constructor_shouldNotThrowException() {
         Map<String, Object> statValues = Map.of("kills", 34, "deaths", 6, "assists", 11);
 

--- a/app/src/test/java/workout_processing/GetGameTest.java
+++ b/app/src/test/java/workout_processing/GetGameTest.java
@@ -151,7 +151,26 @@ public class GetGameTest {
 
         Game actualGame = getGame.getGame();
 
-        String invalidInput = "Please enter an integer value";
+        String invalidInput = "Please enter a non-negative integer value";
+
+        // Check that it caught the invalid input
+        assertTrue(outputStream.toString().contains(invalidInput));
+        // Check that the game was still retrieved correctly
+        assertNotNull(actualGame.getEndTime());
+        assertTrue(actualGame.getWin());
+        assertEquals(Map.of("kills", 25, "deaths", 7, "assists", 10), actualGame.getStatValues());
+    }
+
+    @Test
+    public void handlesNegativeIntInput() {
+        String input = "1\ny\n-13\n25\n7\n10";
+        InputStream in = new ByteArrayInputStream(input.getBytes());
+
+        GetGame getGame = new GetGame(new Scanner(in));
+
+        Game actualGame = getGame.getGame();
+
+        String invalidInput = "Please enter a non-negative integer value";
 
         // Check that it caught the invalid input
         assertTrue(outputStream.toString().contains(invalidInput));
@@ -170,7 +189,7 @@ public class GetGameTest {
 
         Game actualGame = getGame.getGame();
 
-        String invalidInput = "Please enter an integer value";
+        String invalidInput = "Please enter a non-negative integer value";
 
         // Check that it caught the invalid input
         assertTrue(outputStream.toString().contains(invalidInput));


### PR DESCRIPTION
As of 10/26/2025, negative (int) stat values are not supported, so a negative check should be added -- and moved out of the MarvelRivals reps calculation logic.

Issue: #48 

Test: Ran `./gradlew clean build`
