### PR TITLE
Add persistence file

### DIFF
--- a/app/src/main/resources/META-INF/persistence.xml
+++ b/app/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,21 @@
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+             https://jakarta.ee/xml/ns/persistence/persistence_3_2.xsd"
+             version="3.2">
+
+    <persistence-unit name="sqlite-pu" transaction-type="RESOURCE_LOCAL">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <class>com.example.Post</class> <properties>
+            <property name="jakarta.persistence.jdbc.driver" value="org.sqlite.JDBC"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:sqlite:blog.db"/>
+
+            <property name="hibernate.dialect" value="org.hibernate.community.dialect.SQLiteDialect"/>
+            
+            <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
+            
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
Adding a persistence file to be the central configuration file for JPA (Java Persistence API), instructing the persistence provider (Hibernate) on how to manage data.

Issue: #45 

Test: Ran `./gradlew clean build`
